### PR TITLE
fix(workflows): use extended hugo version and checkout v4

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: true
           fetch-depth: 0
@@ -16,6 +16,7 @@ jobs:
         uses: peaceiris/actions-hugo@v2
         with:
           hugo-version: 'latest'
+          extended: true
       - name: Clean public directory
         run: rm -rf public
       - name: Build
@@ -25,4 +26,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public
-          cname: gite-glaise.fr 
+          cname: gite-glaise.fr


### PR DESCRIPTION
### What does this PR do?

Fixes the crappy workflow. I'm taking the easy way out right now. But we should move towards removing all paeciris stuff.